### PR TITLE
Ajordana/profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,16 @@ option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)
 option(BUILD_WITH_PROXSUITE "Build the ProxQP-based SQP solver" OFF)
 option(BUILD_BENCHMARKS "Build the benchmarks" OFF)
 option(CHECK_RUNTIME_MALLOC "Check eigen mallocs" OFF)
+option(ENABLE_VECTORIZATION
+       "Enable vectorization and further processor-related optimizations" OFF)
 
 # Project configuration
 set(PROJECT_USE_CMAKE_EXPORT TRUE)
 set(CUSTOM_HEADER_DIR ${PROJECT_NAME})
+
+if(ENABLE_VECTORIZATION)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/benchmarks/solo12.cpp
+++ b/benchmarks/solo12.cpp
@@ -160,7 +160,7 @@ int main(){
 
         Eigen::VectorXd x_lim; 
         x_lim.resize(nq + nv); 
-        x_lim.head(nq + nv) << 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.;
+        x_lim.head(nq + nv) << Eigen::VectorXd::Ones(nq+nv);
 
         boost::shared_ptr<crocoddyl::ConstraintModelResidual> state_constraint = boost::make_shared<crocoddyl::ConstraintModelResidual>(state, stateResidualc, x0-x_lim, x0+x_lim);
         constraints->addConstraint("State constraint", state_constraint);

--- a/examples/solo12.py
+++ b/examples/solo12.py
@@ -147,7 +147,7 @@ ocp = crocoddyl.ShootingProblem(x0, running_models[:-1], running_models[-1])
 solver = mim_solvers.SolverCSQP(ocp)
 solver.max_qp_iters = 1000
 max_iter = 500
-solver.with_callbacks = True
+solver.setCallbacks([mim_solvers.CallbackVerbose()])
 solver.use_filter_line_search = False
 solver.termination_tolerance = 1e-4
 solver.eps_abs = 1e-6

--- a/examples/ur5.py
+++ b/examples/ur5.py
@@ -98,9 +98,9 @@ xs = [x0] * (T + 1)
 us = [np.zeros(nu)] * T
 
 # Define solver
-solver = mim_solvers.SolverCSQP(problem)
+solver = mim_solvers.SolverSQP(problem)
 solver.termination_tolerance = 1e-4
-solver.with_callbacks = True 
+solver.setCallbacks([mim_solvers.CallbackVerbose()])
 
 # Solve
 max_iter = 100

--- a/examples/ur5.py
+++ b/examples/ur5.py
@@ -98,9 +98,9 @@ xs = [x0] * (T + 1)
 us = [np.zeros(nu)] * T
 
 # Define solver
-solver = mim_solvers.SolverSQP(problem)
+solver = mim_solvers.SolverCSQP(problem)
 solver.termination_tolerance = 1e-4
-solver.setCallbacks([mim_solvers.CallbackVerbose("SQP")])
+solver.setCallbacks([mim_solvers.CallbackVerbose()])
 
 # Solve
 max_iter = 100

--- a/examples/ur5.py
+++ b/examples/ur5.py
@@ -100,7 +100,7 @@ us = [np.zeros(nu)] * T
 # Define solver
 solver = mim_solvers.SolverSQP(problem)
 solver.termination_tolerance = 1e-4
-solver.setCallbacks([mim_solvers.CallbackVerbose()])
+solver.setCallbacks([mim_solvers.CallbackVerbose("SQP")])
 
 # Solve
 max_iter = 100

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -748,8 +748,10 @@ void SolverCSQP::backwardPass() {
     Vx_[t] = Qx_[t];
     Vxx_[t] = Qxx_[t];
     if (nu != 0) {
-      Quuk_[t].noalias() = Quu_[t] * k_[t];
+      // Quuk_[t].noalias() = Quu_[t] * k_[t];
+      START_PROFILER("SolverCSQP::backwardPass::Vx");
       Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
+      STOP_PROFILER("SolverCSQP::backwardPass::Vx");
       START_PROFILER("SolverCSQP::backwardPass::Vxx");
       Vxx_[t].noalias() -= Qxu_[t] * K_[t];
       STOP_PROFILER("SolverCSQP::backwardPass::Vxx");
@@ -828,7 +830,7 @@ void SolverCSQP::backwardPass_without_constraints() {
     Vx_[t] = Qx_[t];
     Vxx_[t] = Qxx_[t];
     if (nu != 0) {
-      Quuk_[t].noalias() = Quu_[t] * k_[t];
+      // Quuk_[t].noalias() = Quu_[t] * k_[t];
       Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
       START_PROFILER("SolverCSQP::backwardPass_without_constraints::Vxx");
       Vxx_[t].noalias() -= Qxu_[t] * K_[t];

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -460,7 +460,7 @@ void SolverCSQP::computeDirection(const bool recalcDiff){
     update_rho_vec(iter);
     
     // Because (eps_rel=0) x inf = NaN
-    if (iter % 25 == 0){
+    if (iter % rho_update_interval_ == 0){
       if(with_qp_callbacks_){
         printQPCallbacks(iter);
       }
@@ -516,6 +516,7 @@ void SolverCSQP::reset_rho_vec(){
 
 
 void SolverCSQP::apply_rho_update(double rho_sparse_tmp_){
+  START_PROFILER("SolverCSQP::apply_rho_update");
   const std::size_t T = this->problem_->get_T();
   const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> >& models = problem_->get_runningModels();
   double infty = std::numeric_limits<double>::infinity();
@@ -557,6 +558,7 @@ void SolverCSQP::apply_rho_update(double rho_sparse_tmp_){
         inv_rho_vec_.back()[k] = 1/rho_sparse_tmp_;
     }
   }
+  STOP_PROFILER("SolverCSQP::apply_rho_update");
 }
 
 void SolverCSQP::checkKKTConditions(){
@@ -602,8 +604,8 @@ void SolverCSQP::forwardPass(const double stepLength){
     (void)stepLength;
 
     START_PROFILER("SolverCSQP::forwardPass");
-    x_grad_norm_ = 0; 
-    u_grad_norm_ = 0;
+    // x_grad_norm_ = 0; 
+    // u_grad_norm_ = 0;
 
     const std::size_t T = problem_->get_T();
     const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstract> >& datas = problem_->get_runningDatas();
@@ -616,13 +618,13 @@ void SolverCSQP::forwardPass(const double stepLength){
       dxtilde_[t+1].noalias() += d->Fu * dutilde_[t];
       dxtilde_[t+1].noalias() += fs_[t+1];
 
-      x_grad_norm_ += dxtilde_[t].lpNorm<1>(); 
-      u_grad_norm_ += dutilde_[t].lpNorm<1>();
+      // x_grad_norm_ += dxtilde_[t].lpNorm<1>(); 
+      // u_grad_norm_ += dutilde_[t].lpNorm<1>();
     }
 
-    x_grad_norm_ += dxtilde_.back().lpNorm<1>(); 
-    x_grad_norm_ = x_grad_norm_/(T+1);
-    u_grad_norm_ = u_grad_norm_/T; 
+    // x_grad_norm_ += dxtilde_.back().lpNorm<1>(); 
+    // x_grad_norm_ = x_grad_norm_/(T+1);
+    // u_grad_norm_ = u_grad_norm_/T; 
     STOP_PROFILER("SolverCSQP::forwardPass");
 
 }
@@ -684,7 +686,7 @@ void SolverCSQP::backwardPass() {
     const std::size_t nu = m->get_nu();
     std::size_t nc = m->get_ng();
     FxTVxx_p_.noalias() = d->Fx.transpose() * Vxx_p;
-    START_PROFILER("SolverCSQP::Qx");
+    START_PROFILER("SolverCSQP::backwardPass::Qx");
     Qx_[t] = d->Lx;
     Qx_[t].noalias() -= sigma_ * dx_[t];
     if (nc != 0){
@@ -697,10 +699,10 @@ void SolverCSQP::backwardPass() {
       Qx_[t] += d->Gx.transpose() * tmp_dual_cwise_[t];
     }
     Qx_[t].noalias() += d->Fx.transpose() * tmp_Vx_;
-    STOP_PROFILER("SolverCSQP::Qx");
+    STOP_PROFILER("SolverCSQP::backwardPass::Qx");
 
 
-    START_PROFILER("SolverCSQP::Qxx");
+    START_PROFILER("SolverCSQP::backwardPass::Qxx");
     Qxx_[t] = d->Lxx; 
     Qxx_[t].diagonal().array() += sigma_;
     if (t > 0 && nc != 0){ 
@@ -708,19 +710,19 @@ void SolverCSQP::backwardPass() {
       Qxx_[t].noalias() += d->Gx.transpose() * tmp_rhoGx_mat_[t];
     }
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
-    STOP_PROFILER("SolverCSQP::Qxx");
+    STOP_PROFILER("SolverCSQP::backwardPass::Qxx");
 
     if (nu != 0) {
-      START_PROFILER("SolverCSQP::Qu");
+      START_PROFILER("SolverCSQP::backwardPass::Qu");
       FuTVxx_p_[t].noalias() = d->Fu.transpose() * Vxx_p;
       Qu_[t] = d->Lu - sigma_ * du_[t];
       if (nc != 0){ 
         Qu_[t] += d->Gu.transpose() * tmp_dual_cwise_[t];
       }
       Qu_[t].noalias() += d->Fu.transpose() * tmp_Vx_;
-      STOP_PROFILER("SolverCSQP::Qu");
+      STOP_PROFILER("SolverCSQP::backwardPass::Qu");
 
-      START_PROFILER("SolverCSQP::Quu");
+      START_PROFILER("SolverCSQP::backwardPass::Quu");
       Quu_[t] = d->Luu; 
       Quu_[t].diagonal().array() += sigma_;
       Quu_[t].noalias() += FuTVxx_p_[t] * d->Fu;
@@ -728,19 +730,19 @@ void SolverCSQP::backwardPass() {
         tmp_rhoGu_mat_[t].noalias() = rho_vec_[t].asDiagonal() * d->Gu;
         Quu_[t].noalias() += d->Gu.transpose() * tmp_rhoGu_mat_[t];
       }
-      STOP_PROFILER("SolverCSQP::Quu");
+      if (!std::isnan(dreg_)) {
+        Quu_[t].diagonal().array() += dreg_;
+      }
+      STOP_PROFILER("SolverCSQP::backwardPass::Quu");
 
-      START_PROFILER("SolverCSQP::Qxu");
+      START_PROFILER("SolverCSQP::backwardPass::Qxu");
       Qxu_[t] = d->Lxu;
       if (t > 0 && nc != 0){ 
         Qxu_[t].noalias() += d->Gx.transpose() * tmp_rhoGu_mat_[t];
       }
       Qxu_[t].noalias() += FxTVxx_p_ * d->Fu;
-      STOP_PROFILER("SolverCSQP::Qxu");
+      STOP_PROFILER("SolverCSQP::backwardPass::Qxu");
 
-      if (!std::isnan(dreg_)) {
-        Quu_[t].diagonal().array() += dreg_;
-      }
     }
     computeGains(t);
     Vx_[t] = Qx_[t];
@@ -748,9 +750,9 @@ void SolverCSQP::backwardPass() {
     if (nu != 0) {
       Quuk_[t].noalias() = Quu_[t] * k_[t];
       Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
-      START_PROFILER("SolverCSQP::Vxx");
+      START_PROFILER("SolverCSQP::backwardPass::Vxx");
       Vxx_[t].noalias() -= Qxu_[t] * K_[t];
-      STOP_PROFILER("SolverCSQP::Vxx");
+      STOP_PROFILER("SolverCSQP::backwardPass::Vxx");
     }
     Vxx_tmp_ = 0.5 * (Vxx_[t] + Vxx_[t].transpose());
     Vxx_[t] = Vxx_tmp_;
@@ -758,12 +760,12 @@ void SolverCSQP::backwardPass() {
       Vxx_[t].diagonal().array() += preg_;
     }
 
-    if (raiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>())) {
-      throw_pretty("backward_error");
-    }
-    if (raiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>())) {
-      throw_pretty("backward_error");
-    }
+    // if (raiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>())) {
+    //   throw_pretty("backward_error");
+    // }
+    // if (raiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>())) {
+    //   throw_pretty("backward_error");
+    // }
   }
   STOP_PROFILER("SolverCSQP::backwardPass");
 }
@@ -790,31 +792,31 @@ void SolverCSQP::backwardPass_without_constraints() {
     tmp_Vx_.noalias() += Vx_[t + 1];
     const std::size_t nu = m->get_nu();
     FxTVxx_p_.noalias() = d->Fx.transpose() * Vxx_p;
-    START_PROFILER("SolverCSQP::Qx");
+    START_PROFILER("SolverCSQP::backwardPass_without_constraints::Qx");
     Qx_[t] = d->Lx;
 
     Qx_[t].noalias() += d->Fx.transpose() * tmp_Vx_;
-    STOP_PROFILER("SolverCSQP::Qx");
-    START_PROFILER("SolverCSQP::Qxx");
+    STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Qx");
+    START_PROFILER("SolverCSQP::backwardPass_without_constraints::Qxx");
     Qxx_[t] = d->Lxx;
     
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
-    STOP_PROFILER("SolverCSQP::Qxx");
+    STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Qxx");
     if (nu != 0) {
       FuTVxx_p_[t].noalias() = d->Fu.transpose() * Vxx_p;
-      START_PROFILER("SolverCSQP::Qu");
+      START_PROFILER("SolverCSQP::backwardPass_without_constraints::Qu");
       Qu_[t] = d->Lu;
       Qu_[t].noalias() += d->Fu.transpose() * tmp_Vx_;
 
-      STOP_PROFILER("SolverCSQP::Qu");
-      START_PROFILER("SolverCSQP::Quu");
+      STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Qu");
+      START_PROFILER("SolverCSQP::backwardPass_without_constraints::Quu");
       Quu_[t] = d->Luu;
       Quu_[t].noalias() += FuTVxx_p_[t] * d->Fu;
-      STOP_PROFILER("SolverCSQP::Quu");
-      START_PROFILER("SolverCSQP::Qxu");
+      STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Quu");
+      START_PROFILER("SolverCSQP::backwardPass_without_constraints::Qxu");
       Qxu_[t] = d->Lxu; 
       Qxu_[t].noalias() += FxTVxx_p_ * d->Fu;
-      STOP_PROFILER("SolverCSQP::Qxu");
+      STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Qxu");
 
       if (!std::isnan(dreg_)) {
         Quu_[t].diagonal().array() += dreg_;
@@ -828,9 +830,9 @@ void SolverCSQP::backwardPass_without_constraints() {
     if (nu != 0) {
       Quuk_[t].noalias() = Quu_[t] * k_[t];
       Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
-      START_PROFILER("SolverCSQP::Vxx");
+      START_PROFILER("SolverCSQP::backwardPass_without_constraints::Vxx");
       Vxx_[t].noalias() -= Qxu_[t] * K_[t];
-      STOP_PROFILER("SolverCSQP::Vxx");
+      STOP_PROFILER("SolverCSQP::backwardPass_without_constraints::Vxx");
     }
     Vxx_tmp_ = 0.5 * (Vxx_[t] + Vxx_[t].transpose());
     Vxx_[t] = Vxx_tmp_;
@@ -856,6 +858,7 @@ void SolverCSQP::backwardPass_without_rho_update() {
   const boost::shared_ptr<crocoddyl::ActionModelAbstract>& m_T = problem_->get_terminalModel();
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& d_T = problem_->get_terminalData();
 
+  START_PROFILER("SolverCSQP::backwardPass_without_rho_update::Vx");
   Vx_.back() = d_T->Lx;
   Vx_.back().noalias() -= sigma_ * dx_.back();
 
@@ -864,66 +867,71 @@ void SolverCSQP::backwardPass_without_rho_update() {
     tmp_dual_cwise_.back().noalias() -= rho_vec_.back().cwiseProduct(z_.back());
     Vx_.back().noalias() += d_T->Gx.transpose() * tmp_dual_cwise_.back();
   }
+  STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update::Vx");
 
   const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> >& models = problem_->get_runningModels();
   const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (int t = static_cast<int>(problem_->get_T()) - 1; t >= 0; --t) {
     const boost::shared_ptr<crocoddyl::ActionModelAbstract>& m = models[t];
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& d = datas[t];
-
-    tmp_Vx_ = Vxx_fs_[t] + Vx_[t + 1];
     const std::size_t nu = m->get_nu();
     std::size_t nc = m->get_ng();
-    START_PROFILER("SolverCSQP::Qx");
+
+    START_PROFILER("SolverCSQP::backwardPass_without_rho_update::Qx");
+    tmp_Vx_ = Vxx_fs_[t] + Vx_[t + 1];
     Qx_[t] = d->Lx;
     Qx_[t].noalias() -= sigma_ * dx_[t];
-
     if (nc != 0){
       if (t > 0 || nu != 0){
       tmp_dual_cwise_[t] = y_[t]; 
       tmp_dual_cwise_[t].noalias() -= rho_vec_[t].cwiseProduct(z_[t]);
       }
     }
-
     if (t > 0 && nc != 0){ 
       Qx_[t].noalias() += d->Gx.transpose() * tmp_dual_cwise_[t];
     }
-
     Qx_[t].noalias() += d->Fx.transpose() * tmp_Vx_;
 
-    STOP_PROFILER("SolverCSQP::Qxx");
+    STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update::Qx");
+
     if (nu != 0) {
-      START_PROFILER("SolverCSQP::Qu");
+      START_PROFILER("SolverCSQP::backwardPass_without_rho_update::Qu");
       Qu_[t] = d->Lu;
       Qu_[t].noalias() -= sigma_ * du_[t];
       if (nc != 0){ 
         Qu_[t].noalias() += d->Gu.transpose() * tmp_dual_cwise_[t];
       }
-
       Qu_[t].noalias() += d->Fu.transpose() * tmp_Vx_;
-
+      STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update::Qu");
     }
 
+    START_PROFILER("SolverCSQP::backwardPass_without_rho_update::k");
     k_[t] = Qu_[t];
     Quu_llt_[t].solveInPlace(k_[t]);
+    STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update::k");
 
+    START_PROFILER("SolverCSQP::backwardPass_without_rho_update::Vx");
     Vx_[t] = Qx_[t];
     if (nu != 0) {
       Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
     }
+    STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update::Vx");
 
-    if (raiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>())) {
-      throw_pretty("backward_error");
-    }
-    if (raiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>())) {
-      throw_pretty("backward_error");
-    }
+    // if (raiseIfNaN(Vx_[t].lpNorm<Eigen::Infinity>())) {
+    //   throw_pretty("backward_error");
+    // }
+    // if (raiseIfNaN(Vxx_[t].lpNorm<Eigen::Infinity>())) {
+    //   throw_pretty("backward_error");
+    // }
   }
   STOP_PROFILER("SolverCSQP::backwardPass_without_rho_update");
 }
 
 
 void SolverCSQP::update_lagrangian_parameters(int iter){
+    START_PROFILER("SolverCSQP::update_lagrangian_parameters");
+
+    START_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
     norm_primal_ = -1* std::numeric_limits<double>::infinity();
     norm_dual_ = -1* std::numeric_limits<double>::infinity();
     norm_primal_rel_ = -1* std::numeric_limits<double>::infinity();
@@ -933,8 +941,11 @@ void SolverCSQP::update_lagrangian_parameters(int iter){
     const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstract> >& datas = problem_->get_runningDatas();
 
     const std::size_t T = problem_->get_T();
+    STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
 
     for (std::size_t t = 0; t < T; ++t) {    
+
+      START_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
 
       const boost::shared_ptr<crocoddyl::ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<crocoddyl::ActionDataAbstract>& d = datas[t];
@@ -968,73 +979,85 @@ void SolverCSQP::update_lagrangian_parameters(int iter){
       dx_[t] = dxtilde_[t];
       du_[t] = dutilde_[t];
 
-    if (iter % 25 == 0){
-      if (update_rho_with_heuristic_){
-        tmp_dual_cwise_[t] = rho_vec_[t].cwiseProduct(z_[t] - z_prev_[t]);
-        norm_dual_ = std::max(norm_dual_, tmp_dual_cwise_[t].lpNorm<Eigen::Infinity>());
-        norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_[t] - z_[t]).lpNorm<Eigen::Infinity>());
 
-        norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_[t].lpNorm<Eigen::Infinity>());
-        norm_primal_rel_= std::max(norm_primal_rel_, z_[t].lpNorm<Eigen::Infinity>());
-        norm_dual_rel_ = std::max(norm_dual_rel_, y_[t].lpNorm<Eigen::Infinity>());
+      STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
+
+      START_PROFILER("SolverCSQP::update_lagrangian_parameters::norms");
+      if (iter % rho_update_interval_ == 0){
+        if (update_rho_with_heuristic_){
+          tmp_dual_cwise_[t] = rho_vec_[t].cwiseProduct(z_[t] - z_prev_[t]);
+          norm_dual_ = std::max(norm_dual_, tmp_dual_cwise_[t].lpNorm<Eigen::Infinity>());
+          norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_[t] - z_[t]).lpNorm<Eigen::Infinity>());
+
+          norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_[t].lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, z_[t].lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, y_[t].lpNorm<Eigen::Infinity>());
+        } 
+        else {
+          tmp_dual_cwise_[t] = rho_vec_[t].cwiseProduct(z_[t] - z_prev_[t]);
+          tmp_vec_x_.noalias() = d->Gx.transpose() * tmp_dual_cwise_[t];
+          tmp_vec_u_[t].noalias() = d->Gu.transpose() * tmp_dual_cwise_[t];
+          norm_dual_ = std::max(norm_dual_, std::max(tmp_vec_x_.lpNorm<Eigen::Infinity>(), tmp_vec_u_[t].lpNorm<Eigen::Infinity>()));
+          norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_[t] - z_[t]).lpNorm<Eigen::Infinity>());
+          
+          norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_[t].lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, z_[t].lpNorm<Eigen::Infinity>());
+          tmp_vec_x_.noalias() = d->Gx.transpose() * y_[t];
+          tmp_vec_u_[t].noalias() = d->Gu.transpose() * y_[t];
+          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_u_[t].lpNorm<Eigen::Infinity>());
+        }
       } 
-      else {
-        tmp_dual_cwise_[t] = rho_vec_[t].cwiseProduct(z_[t] - z_prev_[t]);
-        tmp_vec_x_.noalias() = d->Gx.transpose() * tmp_dual_cwise_[t];
-        tmp_vec_u_[t].noalias() = d->Gu.transpose() * tmp_dual_cwise_[t];
-        norm_dual_ = std::max(norm_dual_, std::max(tmp_vec_x_.lpNorm<Eigen::Infinity>(), tmp_vec_u_[t].lpNorm<Eigen::Infinity>()));
-        norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_[t] - z_[t]).lpNorm<Eigen::Infinity>());
-        
-        norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_[t].lpNorm<Eigen::Infinity>());
-        norm_primal_rel_= std::max(norm_primal_rel_, z_[t].lpNorm<Eigen::Infinity>());
-        tmp_vec_x_.noalias() = d->Gx.transpose() * y_[t];
-        tmp_vec_u_[t].noalias() = d->Gu.transpose() * y_[t];
-        norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
-        norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_u_[t].lpNorm<Eigen::Infinity>());
-      }
-    }
+      STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::norms");
     }
 
-  dx_.back() = dxtilde_.back();
-  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& m_T = problem_->get_terminalModel();
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& d_T = problem_->get_terminalData();
-  std::size_t nc = m_T->get_ng();
+    START_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
+    dx_.back() = dxtilde_.back();
+    const boost::shared_ptr<crocoddyl::ActionModelAbstract>& m_T = problem_->get_terminalModel();
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& d_T = problem_->get_terminalData();
+    std::size_t nc = m_T->get_ng();
+    STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
 
-  if (nc != 0){
-    z_prev_.back() = z_.back();
-    tmp_Cdx_Cdu_.back().noalias() = d_T->Gx * dxtilde_.back() ;
-    z_relaxed_.back().noalias() = alpha_ * tmp_Cdx_Cdu_.back();
-    z_relaxed_.back().noalias() += (1 - alpha_) * z_.back();
+    if (nc != 0){
+      START_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
+      z_prev_.back() = z_.back();
+      tmp_Cdx_Cdu_.back().noalias() = d_T->Gx * dxtilde_.back() ;
+      z_relaxed_.back().noalias() = alpha_ * tmp_Cdx_Cdu_.back();
+      z_relaxed_.back().noalias() += (1 - alpha_) * z_.back();
 
-    tmp_dual_cwise_.back() = y_.back().cwiseProduct(inv_rho_vec_.back());
-    z_.back() = (z_relaxed_.back() + tmp_dual_cwise_.back());
-    z_.back() = z_.back().cwiseMax(m_T->get_g_lb() - d_T->g).cwiseMin(m_T->get_g_ub() - d_T->g);
-    y_.back() += rho_vec_.back().cwiseProduct(z_relaxed_.back() - z_.back());
-    
+      tmp_dual_cwise_.back() = y_.back().cwiseProduct(inv_rho_vec_.back());
+      z_.back() = (z_relaxed_.back() + tmp_dual_cwise_.back());
+      z_.back() = z_.back().cwiseMax(m_T->get_g_lb() - d_T->g).cwiseMin(m_T->get_g_ub() - d_T->g);
+      y_.back() += rho_vec_.back().cwiseProduct(z_relaxed_.back() - z_.back());
+      
+      STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::update");
 
-    if (iter % 25 == 0){
-      if (update_rho_with_heuristic_){
-        tmp_dual_cwise_.back() = rho_vec_.back().cwiseProduct(z_.back() - z_prev_.back());
-        norm_dual_ = std::max(norm_dual_, tmp_dual_cwise_.back().lpNorm<Eigen::Infinity>());
-        norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_.back() - z_.back()).lpNorm<Eigen::Infinity>());
+      START_PROFILER("SolverCSQP::update_lagrangian_parameters::norms");
+      if (iter % rho_update_interval_ == 0){
+        if (update_rho_with_heuristic_){
+          tmp_dual_cwise_.back() = rho_vec_.back().cwiseProduct(z_.back() - z_prev_.back());
+          norm_dual_ = std::max(norm_dual_, tmp_dual_cwise_.back().lpNorm<Eigen::Infinity>());
+          norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_.back() - z_.back()).lpNorm<Eigen::Infinity>());
 
-        norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_.back().lpNorm<Eigen::Infinity>());
-        norm_primal_rel_= std::max(norm_primal_rel_, z_.back().lpNorm<Eigen::Infinity>());
-        norm_dual_rel_ = std::max(norm_dual_rel_, y_.back().lpNorm<Eigen::Infinity>());
-      }
-      else {
-        tmp_dual_cwise_.back() = rho_vec_.back().cwiseProduct(z_.back() - z_prev_.back());
-        tmp_vec_x_.noalias() = d_T->Gx.transpose() * tmp_dual_cwise_.back();
-        norm_dual_ = std::max(norm_dual_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
-        norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_.back() - z_.back()).lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_.back().lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, z_.back().lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, y_.back().lpNorm<Eigen::Infinity>());
+        }
+        else {
+          tmp_dual_cwise_.back() = rho_vec_.back().cwiseProduct(z_.back() - z_prev_.back());
+          tmp_vec_x_.noalias() = d_T->Gx.transpose() * tmp_dual_cwise_.back();
+          norm_dual_ = std::max(norm_dual_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+          norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_.back() - z_.back()).lpNorm<Eigen::Infinity>());
 
-        norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_.back().lpNorm<Eigen::Infinity>());
-        norm_primal_rel_= std::max(norm_primal_rel_, z_.back().lpNorm<Eigen::Infinity>());
-        tmp_vec_x_.noalias() = d_T->Gx.transpose() * y_.back();
-        norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_.back().lpNorm<Eigen::Infinity>());
+          norm_primal_rel_= std::max(norm_primal_rel_, z_.back().lpNorm<Eigen::Infinity>());
+          tmp_vec_x_.noalias() = d_T->Gx.transpose() * y_.back();
+          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+        }
       }
     }
-  }
+    STOP_PROFILER("SolverCSQP::update_lagrangian_parameters::norms");
+    STOP_PROFILER("SolverCSQP::update_lagrangian_parameters");
 }
 
 

--- a/src/utils/callbacks.cpp
+++ b/src/utils/callbacks.cpp
@@ -86,16 +86,6 @@ void CallbackVerbose::update_header() {
 void CallbackVerbose::operator()(SolverAbstract& solver) {
   if (solver.get_iter() % 10 == 0) {
     std::cout << header_ << std::endl;
-  }
-  auto space_sign = [this](const double value) {
-    std::stringstream stream;
-    if (value >= 0.) {
-      stream << " ";
-    } else {
-      stream << "-";
-    }
-    stream << std::scientific << std::setprecision(precision_) << abs(value);
-    return stream.str();
   };
 
   std::cout << std::setw(4) << solver.get_iter() << separator_;                                     // iter
@@ -111,12 +101,12 @@ void CallbackVerbose::operator()(SolverAbstract& solver) {
         std::cout << std::scientific << std::setprecision(precision_)
                     << solver_cast.get_constraint_norm() << separator_;                                  // ||Constraint||
         std::cout << std::scientific << std::setprecision(precision_) 
-                    << "       ---- "  << separator_;                                                   // No ||(dx,du)||
-        std::cout << std::scientific << std::setprecision(precision_)
+                    << "       ---- "  << separator_ ;                                                   // No ||(dx,du)||
+        std::cout << std::fixed << std::setprecision(precision_)
                     << "     ---- "  << separator_ << separator_;                                                  // No step
         std::cout << std::scientific << std::setprecision(precision_)
-                    << solver_cast.get_KKT() << separator_ << separator_;                                              // KKT criteria
-        std::cout << std::scientific << std::setprecision(precision_)
+                    << solver_cast.get_KKT() << separator_ << separator_short_;                                              // KKT criteria
+        std::cout << std::fixed << std::setprecision(0)
                     << "    -----" << separator_;                                                       // No QP iters     
         }else{
         std::cout << std::scientific << std::setprecision(precision_)
@@ -128,12 +118,12 @@ void CallbackVerbose::operator()(SolverAbstract& solver) {
         std::cout << std::scientific << std::setprecision(precision_)
                     << solver_cast.get_constraint_norm() << separator_ << separator_ << separator_;                                  // ||Constraint||
         std::cout << std::scientific << std::setprecision(precision_) 
-                    << (solver_cast.get_xgrad_norm() + solver_cast.get_ugrad_norm()) / 2  << separator_ << separator_;      // ||(dx,du)||
-        std::cout << std::scientific << std::setprecision(precision_)
-                    << solver_cast.get_steplength() << separator_ ;                                       // step
+                    << (solver_cast.get_xgrad_norm() + solver_cast.get_ugrad_norm()) / 2  << separator_ << separator_<< separator_;      // ||(dx,du)||
+        std::cout << std::fixed << std::setprecision(precision_)
+                    << solver_cast.get_steplength() << separator_  << separator_;                                       // step
         std::cout << std::scientific << std::setprecision(precision_)
                     << solver_cast.get_KKT() << separator_ << separator_ << separator_short_;                                              // KKT criteria
-        std::cout << std::scientific << std::setprecision(precision_)
+        std::cout << std::fixed << std::setprecision(0) << separator_short_
                     << solver_cast.get_qp_iters() << separator_;                                         // QP iters                            
       
         }


### PR DESCRIPTION
## Description

- `x_grad_norm_` and `u_grad_norm_` are now computed in checkKKTconditions. This avoids to compute them at every iteration of the QP solver.
- Fixed callbacks in example.
- Added ENABLE_VECTORIZATION option to the CMake.
- Added state constraint to the solo12 benchmark.
- Removed check on Vxx norm. 
