### PR TITLE
CSQP: add parallelization and update the merit function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+build*/
 develop-eggs/
 dist/
 downloads/

--- a/bindings/csqp.cpp
+++ b/bindings/csqp.cpp
@@ -109,7 +109,9 @@ void exposeSolverCSQP() {
                     "KKT residual norm")
       .add_property("merit", bp::make_function(&SolverCSQP::get_merit),
                     "Merit function value")
-                          
+
+      .add_property("lag_mul_inf_norm_coef", bp::make_function(&SolverCSQP::get_lag_mul_inf_norm_coef), bp::make_function(&SolverCSQP::set_lag_mul_inf_norm_coef),
+                    "Scaling coefficient for the Lagrange multipliers norm in Nocedal's L1 merit function (default: 10.)")                   
       .add_property("mu_dynamic", bp::make_function(&SolverCSQP::get_mu_dynamic), bp::make_function(&SolverCSQP::set_mu_dynamic),
                     "Penalty weight for dynamic violation in the merit function (default: 10.)")
       .add_property("mu_constraint", bp::make_function(&SolverCSQP::get_mu_constraint), bp::make_function(&SolverCSQP::set_mu_constraint),

--- a/examples/solo12.py
+++ b/examples/solo12.py
@@ -150,6 +150,8 @@ max_iter = 500
 solver.setCallbacks([mim_solvers.CallbackVerbose()])
 solver.use_filter_line_search = False
 solver.termination_tolerance = 1e-4
+solver.mu_dynamic = -1 # use Nocedal's L1 merit based on Lagrange multipliers norm
+solver.lag_mul_inf_norm_coef = 10.
 solver.eps_abs = 1e-6
 solver.eps_rel = 1e-6
 

--- a/include/mim_solvers/csqp.hpp
+++ b/include/mim_solvers/csqp.hpp
@@ -142,6 +142,7 @@ class SolverCSQP : public SolverDDP {
   double get_merit() const { return merit_; };
   bool get_extra_iteration_for_last_kkt() const { return extra_iteration_for_last_kkt_; };
   bool get_use_filter_line_search() const { return use_filter_line_search_; };
+  double get_lag_mul_inf_norm_coef() const { return lag_mul_inf_norm_coef_; };
   double get_mu_dynamic() const { return mu_dynamic_; };
   double get_mu_constraint() const { return mu_constraint_; };
   double get_termination_tolerance() const { return termination_tol_; };
@@ -180,6 +181,7 @@ class SolverCSQP : public SolverDDP {
   void set_rho_update_interval(std::size_t interval) { rho_update_interval_ = interval; };
   void set_adaptive_rho_tolerance(std::size_t tolerance) { adaptive_rho_tolerance_ = tolerance; };
 
+  void set_lag_mul_inf_norm_coef(double lag_mul_inf_norm_coef) { lag_mul_inf_norm_coef_ = lag_mul_inf_norm_coef; };
   void set_mu_dynamic(double mu_dynamic) { mu_dynamic_ = mu_dynamic; };
   void set_mu_constraint(double mu_constraint) { mu_constraint_ = mu_constraint; };
   void set_alpha(double alpha) { alpha_ = alpha; };
@@ -219,6 +221,7 @@ class SolverCSQP : public SolverDDP {
   std::vector<Eigen::VectorXd> du_;                            //!< the descent direction for u
   std::vector<Eigen::VectorXd> lag_mul_;                       //!< the Lagrange multiplier of the dynamics constraint
   double lag_mul_inf_norm_;                                    //!< the infinite norm of Lagrange multiplier
+  double lag_mul_inf_norm_coef_ = 10.;                               //!< merit function coefficient scaling the infinite norm of Lagrange multiplier
   Eigen::VectorXd fs_flat_;                                    //!< Gaps/defects between shooting nodes (1D array)
   bool use_filter_line_search_ = true;                         //!< Use filter line search
 

--- a/include/mim_solvers/csqp.hpp
+++ b/include/mim_solvers/csqp.hpp
@@ -89,6 +89,8 @@ class SolverCSQP : public SolverDDP {
   virtual void backwardPass();
   virtual void backwardPass_without_rho_update();
   virtual void backwardPass_without_constraints();
+  virtual void backwardPass_mt();
+  virtual void backwardPass_without_rho_update_mt();
 
   /**
    * @brief Computes the merit function, gaps at the given xs, us along with delta x and delta u

--- a/include/mim_solvers/csqp.hpp
+++ b/include/mim_solvers/csqp.hpp
@@ -216,6 +216,7 @@ class SolverCSQP : public SolverDDP {
   std::vector<Eigen::VectorXd> dx_;                            //!< the descent direction for x
   std::vector<Eigen::VectorXd> du_;                            //!< the descent direction for u
   std::vector<Eigen::VectorXd> lag_mul_;                       //!< the Lagrange multiplier of the dynamics constraint
+  double lag_mul_inf_norm_;                                    //!< the infinite norm of Lagrange multiplier
   Eigen::VectorXd fs_flat_;                                    //!< Gaps/defects between shooting nodes (1D array)
   bool use_filter_line_search_ = true;                         //!< Use filter line search
 

--- a/python/csqp.py
+++ b/python/csqp.py
@@ -32,6 +32,8 @@ class CSQP(StagewiseADMM, QPSolvers):
 
         self.mu1 = 1e1
         self.mu2 = 1e1
+        self.lag_mul_inf_norm_coef = 1.01
+        self.lag_mul_inf_norm = 0
         self.termination_tolerance = 1e-6
 
         self.iter = 0
@@ -81,7 +83,11 @@ class CSQP(StagewiseADMM, QPSolvers):
 
 
         self.gap_norm_try = sum(np.linalg.norm(self.gap_try, 1, axis = 1))
-        self.merit_try =  self.cost_try + self.mu1 * self.gap_norm_try + self.mu2 * self.constraint_norm_try
+
+        if(self.mu1 < 0  or self.mu2 < 0):
+            self.merit_try =  self.cost_try + self.lag_mul_inf_norm_coef * self.lag_mul_inf_norm * (self.gap_norm_try + self.constraint_norm_try)
+        else:
+            self.merit_try =  self.cost_try + self.mu1 * self.gap_norm_try + self.mu2 * self.constraint_norm_try
    
     def LQ_problem_KKT_check(self):
         KKT = 0

--- a/python/qp_solvers/stagewise_qp.py
+++ b/python/qp_solvers/stagewise_qp.py
@@ -101,8 +101,17 @@ class StagewiseADMM(SolverAbstract):
 
         self.gap_norm = sum(np.linalg.norm(self.gap.copy(), 1, axis = 1))
         self.gap = self.gap.copy()
-
-        self.merit =  self.cost + self.mu1 * self.gap_norm + self.mu2 * self.constraint_norm
+        
+        if(self.mu1 < 0  or self.mu2 < 0):
+            self.lag_mul_inf_norm = 0
+            for lag_mul in self.lag_mul:
+                self.lag_mul_inf_norm = max(self.lag_mul_inf_norm, np.linalg.norm(lag_mul, np.inf))
+            for y in self.y:
+                if len(y) > 0:
+                    self.lag_mul_inf_norm = max(self.lag_mul_inf_norm, np.linalg.norm(y, np.inf))
+            self.merit =  self.cost + self.lag_mul_inf_norm_coef * self.lag_mul_inf_norm * (self.gap_norm + self.constraint_norm)
+        else:
+            self.merit =  self.cost + self.mu1 * self.gap_norm + self.mu2 * self.constraint_norm
 
     def computeDirection(self):
 

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -297,6 +297,8 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       lag_mul_inf_norm_ = 0;
       for (auto const& lag_mul : lag_mul_)
         lag_mul_inf_norm_ = std::max(lag_mul_inf_norm_, lag_mul.lpNorm<Eigen::Infinity>());
+      for (auto const&y : y_)
+        lag_mul_inf_norm_ = std::max(lag_mul_inf_norm_, y.lpNorm<Eigen::Infinity>());
       merit_ = cost_ + lag_mul_inf_norm_ * (gap_norm_ + constraint_norm_);
     } else
       merit_ = cost_ + mu_dynamic_ * gap_norm_ + mu_constraint_ * constraint_norm_;

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -303,6 +303,7 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
 
 
     // We need to recalculate the derivatives when the step length passes
+    bool found = false;
     for (std::vector<double>::const_iterator it = alphas_.begin(); it != alphas_.end(); ++it) {
       steplength_ = *it;
       try {
@@ -320,6 +321,7 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
         }
         if( is_worse_than_memory_ == false ) {
           setCandidate(xs_try_, us_try_, false);
+          found = true;
           break;
         } 
       }
@@ -327,11 +329,13 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
       else{
         if (merit_ > merit_try_) {
           setCandidate(xs_try_, us_try_, false);
+          found = true;
           break;
         }
       }
     }
-
+    if (!found)
+      break;
 
     // Regularization logic
     if(remove_reg_ == false){

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -588,12 +588,10 @@ void SolverCSQP::checkKKTConditions(){
   x_grad_norm_ = 0; 
   u_grad_norm_ = 0;
 
-  for (std::size_t t = 0; t < T; ++t) {
+  for (std::size_t t = 0; t < T + 1; ++t) {
     lag_mul_[t].noalias() = Vx_[t];
     lag_mul_[t].noalias() += Vxx_[t] * dxtilde_[t];
   }
-  lag_mul_.back().noalias() = Vx_.back();
-  lag_mul_.back().noalias() += Vxx_.back() * dxtilde_.back() ;
   const std::size_t ndx = problem_->get_ndx();
   const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (std::size_t t = 0; t < T; ++t) {
@@ -1207,17 +1205,14 @@ void SolverCSQP::update_lagrangian_parameters(int iter){
         } 
         else {
           tmp_dual_cwise_[t] = rho_vec_[t].cwiseProduct(z_[t] - z_prev_[t]);
-          tmp_vec_x_.noalias() = d->Gx.transpose() * tmp_dual_cwise_[t];
-          tmp_vec_u_[t].noalias() = d->Gu.transpose() * tmp_dual_cwise_[t];
-          norm_dual_ = std::max(norm_dual_, std::max(tmp_vec_x_.lpNorm<Eigen::Infinity>(), tmp_vec_u_[t].lpNorm<Eigen::Infinity>()));
+          norm_dual_ = std::max(norm_dual_, (d->Gx.transpose() * tmp_dual_cwise_[t]).lpNorm<Eigen::Infinity>());
+          norm_dual_ = std::max(norm_dual_, (d->Gu.transpose() * tmp_dual_cwise_[t]).lpNorm<Eigen::Infinity>());
           norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_[t] - z_[t]).lpNorm<Eigen::Infinity>());
           
           norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_[t].lpNorm<Eigen::Infinity>());
           norm_primal_rel_= std::max(norm_primal_rel_, z_[t].lpNorm<Eigen::Infinity>());
-          tmp_vec_x_.noalias() = d->Gx.transpose() * y_[t];
-          tmp_vec_u_[t].noalias() = d->Gu.transpose() * y_[t];
-          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
-          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_u_[t].lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, (d->Gx.transpose() * y_[t]).lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, (d->Gu.transpose() * y_[t]).lpNorm<Eigen::Infinity>());
         }
       } 
     }
@@ -1250,14 +1245,12 @@ void SolverCSQP::update_lagrangian_parameters(int iter){
         }
         else {
           tmp_dual_cwise_.back() = rho_vec_.back().cwiseProduct(z_.back() - z_prev_.back());
-          tmp_vec_x_.noalias() = d_T->Gx.transpose() * tmp_dual_cwise_.back();
-          norm_dual_ = std::max(norm_dual_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+          norm_dual_ = std::max(norm_dual_, (d_T->Gx.transpose() * tmp_dual_cwise_.back()).lpNorm<Eigen::Infinity>());
           norm_primal_ = std::max(norm_primal_, (tmp_Cdx_Cdu_.back() - z_.back()).lpNorm<Eigen::Infinity>());
 
           norm_primal_rel_= std::max(norm_primal_rel_, tmp_Cdx_Cdu_.back().lpNorm<Eigen::Infinity>());
           norm_primal_rel_= std::max(norm_primal_rel_, z_.back().lpNorm<Eigen::Infinity>());
-          tmp_vec_x_.noalias() = d_T->Gx.transpose() * y_.back();
-          norm_dual_rel_ = std::max(norm_dual_rel_, tmp_vec_x_.lpNorm<Eigen::Infinity>());
+          norm_dual_rel_ = std::max(norm_dual_rel_, (d_T->Gx.transpose() * y_.back()).lpNorm<Eigen::Infinity>());
         }
       }
     }

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -299,7 +299,7 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
         lag_mul_inf_norm_ = std::max(lag_mul_inf_norm_, lag_mul.lpNorm<Eigen::Infinity>());
       for (auto const&y : y_)
         lag_mul_inf_norm_ = std::max(lag_mul_inf_norm_, y.lpNorm<Eigen::Infinity>());
-      merit_ = cost_ + lag_mul_inf_norm_ * (gap_norm_ + constraint_norm_);
+      merit_ = cost_ + lag_mul_inf_norm_coef_ * lag_mul_inf_norm_ * (gap_norm_ + constraint_norm_);
     } else
       merit_ = cost_ + mu_dynamic_ * gap_norm_ + mu_constraint_ * constraint_norm_;
 
@@ -1326,7 +1326,7 @@ double SolverCSQP::tryStep(const double steplength) {
     constraint_norm_try_ += (d_ter->g - m_ter->get_g_ub()).cwiseMax(Eigen::VectorXd::Zero(nc)).lpNorm<1>();
 
     if (mu_dynamic_ < 0 || mu_constraint_ < 0)
-      merit_try_ = cost_try_ + lag_mul_inf_norm_ * (gap_norm_try_ + constraint_norm_try_);
+      merit_try_ = cost_try_ + lag_mul_inf_norm_coef_ * lag_mul_inf_norm_ * (gap_norm_try_ + constraint_norm_try_);
     else
       merit_try_ = cost_try_ + mu_dynamic_ * gap_norm_try_ + mu_constraint_ * constraint_norm_try_;
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This PR introduces two changes:
- it allows to run some steps of `CSQP::solve` using multiple threads.
- it allows to use the Lagrange multipliers in the merit function.

### Multi-threading

I have intentionally kept both the original single threaded and the multi-threaded versions. When the number of threads is set to 1, the original single threaded version is used because a single threaded version is always faster than a multi-threaded version using only 1 thread.

This allows a fair comparison between multi-threaded and single thread.

### Merit function

Based on section *Merit function* of chapter 18 (Sequential Quadratic Programming) of Numerical Optimization 2nd edition from Nocedal & Wright, I have added a way to the use the infinite norm of the Lagrange multipliers as value for the coefficient of the merit function.
To use this new feature, the user must provide a negative value for either mu_dynamic or mu_constraint.

**Important** I believe the current implementation is not complete as the Lagrange multipliers of the constraint are not calculated (based on code comment, not code understanding).

## How I Tested

Both changes are tested in the same scenario. One 7 dofs Panda robot that must reach an end-effector 6D target while avoiding a collision. I have used different horizons (nb nodes as well as time steps).

### Multi threading

When testing multi-threading, one should be careful to find the number of threads that gives the best performances. In my case, 6 threads is the optimum. More threads reduces the performances.

With 6 threads, the computation time is divided into 2 approximately.

Enabling the profilers helps to have a deeper understanding of where are the improvements. The most notable improvement is on the `backward_without_rho_update` step, which is significantly faster with more threads. I haven't tried but I may be able to have an even better result by decreasing the rho update frequency.

Note that this depends on recent changes in crocoddyl (not released at the time of writing).

### Merit function

To use Lagrange multiplies

## Do not merge before

This is not blocking for merging into devel but it is blocking for releasing.
- [ ] https://github.com/loco-3d/crocoddyl/pull/1334

## I fulfilled the following requirements

I opened this PR to start a discussion. I'll fulfill the below requirements when the proposed ideas have been accepted.

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
