### PR TITLE
Maximum resolution time as stopping criterion

### DIFF
--- a/bindings/csqp.cpp
+++ b/bindings/csqp.cpp
@@ -230,7 +230,14 @@ void exposeSolverCSQP() {
       .add_property("adaptive_rho_tolerance",
                     bp::make_function(&SolverCSQP::get_adaptive_rho_tolerance),
                     bp::make_function(&SolverCSQP::set_adaptive_rho_tolerance),
-                    "get and set adaptive rho tolerance");
+                    "get and set adaptive rho tolerance")
+      .add_property("max_solve_time",
+                    bp::make_function(&SolverCSQP::get_max_solve_time),
+                    bp::make_function(&SolverCSQP::set_max_solve_time),
+                    "get and set max solve time")
+      .add_property("max_solve_time_reached",
+                    bp::make_function(&SolverCSQP::get_max_solve_time_reached),
+                    "get if solver timed out");
 }
 
 }  // namespace mim_solvers

--- a/include/mim_solvers/csqp.hpp
+++ b/include/mim_solvers/csqp.hpp
@@ -11,6 +11,7 @@
 
 #include <Eigen/Cholesky>
 #include <boost/circular_buffer.hpp>
+#include <limits>
 #include <vector>
 
 #include "mim_solvers/ddp.hpp"
@@ -190,6 +191,8 @@ class SolverCSQP : public SolverDDP {
   double get_reset_rho() const { return reset_rho_; };
   double get_rho_min() const { return rho_min_; };
   double get_rho_max() const { return rho_max_; };
+  double get_max_solve_time() const { return max_solve_time_; };
+  bool get_max_solve_time_reached() const { return max_solve_time_reached_; };
 
   bool getQPCallbacks() const { return with_qp_callbacks_; };
 
@@ -240,6 +243,9 @@ class SolverCSQP : public SolverDDP {
   void set_max_qp_iters(const int iters) { max_qp_iters_ = iters; };
   void set_eps_abs(const double eps_abs) { eps_abs_ = eps_abs; };
   void set_eps_rel(const double eps_rel) { eps_rel_ = eps_rel; };
+  void set_max_solve_time(const double max_solve_time) {
+    max_solve_time_ = max_solve_time;
+  };
 
  public:
   boost::circular_buffer<double>
@@ -342,6 +348,10 @@ class SolverCSQP : public SolverDDP {
   std::vector<Eigen::MatrixXd> tmp_rhoGx_mat_;   //!< Temporary variable
   std::vector<Eigen::MatrixXd> tmp_rhoGu_mat_;   //!< Temporary variable
   std::vector<Eigen::VectorXd> Vxx_fs_;          //!< Temporary variable
+
+  double start_time_ = 0.0;
+  bool max_solve_time_reached_ = false;
+  double max_solve_time_ = std::numeric_limits<double>::infinity();
 };
 
 }  // namespace mim_solvers

--- a/include/mim_solvers/csqp.hpp
+++ b/include/mim_solvers/csqp.hpp
@@ -349,9 +349,12 @@ class SolverCSQP : public SolverDDP {
   std::vector<Eigen::MatrixXd> tmp_rhoGu_mat_;   //!< Temporary variable
   std::vector<Eigen::VectorXd> Vxx_fs_;          //!< Temporary variable
 
-  double start_time_ = 0.0;
-  bool max_solve_time_reached_ = false;
-  double max_solve_time_ = std::numeric_limits<double>::infinity();
+  double start_time_ = 0.0;  // Time when the solve function was called
+  bool max_solve_time_reached_ = false;  // Flag indicating solver timedout
+  double max_solve_time_ =
+      std::numeric_limits<double>::infinity();  // Maximum time in seconds used
+                                                // to stop execution of the
+                                                // solver
 };
 
 }  // namespace mim_solvers

--- a/src/csqp.cpp
+++ b/src/csqp.cpp
@@ -238,7 +238,6 @@ bool SolverCSQP::solve(const std::vector<Eigen::VectorXd>& init_xs,
   for (iter_ = 0; iter_ < maxiter; ++iter_) {
     if (crocoddyl::getProfiler().take_time() - start_time_ >= max_solve_time_) {
       max_solve_time_reached_ = true;
-      std::cerr << "timed out" << std::endl;
       break;
     }
     // Compute gradients
@@ -466,12 +465,11 @@ void SolverCSQP::computeDirection(const bool /*recalcDiff*/) {
 
   std::size_t iter = 1;
   for (iter = 1; iter < max_qp_iters_ + 1; ++iter) {
+    if (crocoddyl::getProfiler().take_time() - start_time_ >= max_solve_time_) {
+      max_solve_time_reached_ = true;
+      break;
+    }
     if (iter % rho_update_interval_ == 1 || rho_update_interval_ == 1) {
-      if (crocoddyl::getProfiler().take_time() - start_time_ >=
-          max_solve_time_) {
-        max_solve_time_reached_ = true;
-        break;
-      }
 #ifdef CROCODDYL_WITH_MULTITHREADING
       if (problem_->get_nthreads() > 1)
         backwardPass_mt();


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This PR is response to https://github.com/machines-in-motion/mim_solvers/issues/41. It adds time stopping criterion, triggered when timeout was already reached, meaning there is no predictive time stop criterion.

Results can be seen below:
| Timeout set to  20 ms  | Timeout disabled |
| -------- | ------- |
| ![benchmark_scene_2_max_time_20 0](https://github.com/user-attachments/assets/64e600a4-05c9-4919-bea7-bb17058adcaa)  | ![benchmark_scene_2_max_time_inf](https://github.com/user-attachments/assets/44498ac5-1dbb-4561-b196-268972ff6460)  |


## How I Tested

All the unittests are passing. For the feature for now I used [benchmark from colmpc](https://github.com/agimus-project/colmpc/blob/main/examples/benchmark.py) with additional gathering of the timing.

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

Not in conflict with any of the other PRs.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
