### PR TITLE
CMake: BUILD_STANDALONE_PYTHON_INTERFACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.22)
 
 # Project properties
 set(PROJECT_NAMESPACE machines-in-motion)
@@ -16,7 +16,6 @@ set(CMAKE_VERBOSE_MAKEFILE True)
 add_compile_options(--warn-no-conversion)
 
 # Project options
-option(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)
 option(BUILD_WITH_PROXSUITE "Build the ProxQP-based SQP solver" OFF)
 option(BUILD_BENCHMARKS "Build the benchmarks" OFF)
@@ -47,14 +46,6 @@ else()
       TARGET jrl-cmakemodules::jrl-cmakemodules
       PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
     message(STATUS "JRL cmakemodules found on system at ${JRL_CMAKE_MODULES}")
-  elseif(${CMAKE_VERSION} VERSION_LESS "3.14.0")
-    message(
-      FATAL_ERROR
-        "\nCan't find jrl-cmakemodules. Please either:\n"
-        "  - use git submodule: 'git submodule update --init'\n"
-        "  - or install https://github.com/jrl-umi3218/jrl-cmakemodules\n"
-        "  - or upgrade your CMake version to >= 3.14 to allow automatic fetching\n"
-    )
   else()
     message(STATUS "JRL cmakemodules not found. Let's fetch it.")
     include(FetchContent)
@@ -129,25 +120,33 @@ if(BUILD_WITH_PROXSUITE)
   list(APPEND ${PROJECT_NAME}_SOURCES src/csqp_proxqp.cpp)
 endif(BUILD_WITH_PROXSUITE)
 
-add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}
-                                   ${${PROJECT_NAME}_HEADERS})
-target_include_directories(
-  ${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+if(BUILD_STANDALONE_PYTHON_INTERFACE)
+  add_project_dependency(${PROJECT_NAME} REQUIRED CONFIG)
+  set(PROJECT_EXPORT_NO_TARGET ON)
+else()
+  add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}
+                                     ${${PROJECT_NAME}_HEADERS})
+  add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+  target_include_directories(
+    ${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-if(SUFFIX_SO_VERSION)
-  set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION})
-endif()
+  if(SUFFIX_SO_VERSION)
+    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION
+                                                     ${PROJECT_VERSION})
+  endif()
 
-# Main Executable
-target_link_libraries(${PROJECT_NAME} crocoddyl::crocoddyl)
-if(BUILD_WITH_PROXSUITE)
-  target_link_libraries(${PROJECT_NAME} proxsuite::proxsuite)
-endif()
+  # Main Executable
+  target_link_libraries(${PROJECT_NAME} crocoddyl::crocoddyl)
+  if(BUILD_WITH_PROXSUITE)
+    target_link_libraries(${PROJECT_NAME} proxsuite::proxsuite)
+  endif()
 
-if(UNIX)
-  get_relative_rpath(${CMAKE_INSTALL_LIBDIR} ${PROJECT_NAME}_INSTALL_RPATH)
-  set_target_properties(
-    ${PROJECT_NAME} PROPERTIES INSTALL_RPATH "${${PROJECT_NAME}_INSTALL_RPATH}")
+  if(UNIX)
+    get_relative_rpath(${CMAKE_INSTALL_LIBDIR} ${PROJECT_NAME}_INSTALL_RPATH)
+    set_target_properties(
+      ${PROJECT_NAME} PROPERTIES INSTALL_RPATH
+                                 "${${PROJECT_NAME}_INSTALL_RPATH}")
+  endif()
 endif()
 
 # Python Bindings
@@ -161,13 +160,14 @@ if(BUILD_TESTING)
 endif()
 
 # Benchmarks
-if(BUILD_BENCHMARKS)
+if(BUILD_BENCHMARKS AND NOT BUILD_STANDALONE_PYTHON_INTERFACE)
   add_subdirectory(benchmarks)
 endif()
 
 # Installation
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT ${TARGETS_EXPORT_NAME}
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+if(NOT BUILD_STANDALONE_PYTHON_INTERFACE)
+  install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${TARGETS_EXPORT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -8,8 +8,8 @@ add_library(${PROJECT_NAME}_BENCHMARK_TOOLS SHARED
 foreach(BENCHMARK_NAME ${${PROJECT_NAME}_BENCHMARK})
   add_executable(${BENCHMARK_NAME} ${BENCHMARK_NAME}.cpp)
   target_link_libraries(
-    ${BENCHMARK_NAME} ${PROJECT_NAME} example-robot-data::example-robot-data
-    ${PROJECT_NAME}_BENCHMARK_TOOLS)
+    ${BENCHMARK_NAME} ${PROJECT_NAME}::${PROJECT_NAME}
+    example-robot-data::example-robot-data ${PROJECT_NAME}_BENCHMARK_TOOLS)
   add_custom_target("benchmarks-cpp-${BENCHMARK_NAME}" ${BENCHMARK_NAME}
                                                        \${INPUT})
 endforeach(BENCHMARK_NAME ${${PROJECT_NAME}_BENCHMARK})

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -17,7 +17,8 @@ if(BUILD_WITH_PROXSUITE)
 endif(BUILD_WITH_PROXSUITE)
 
 add_library(${PY_NAME} MODULE ${${PY_NAME}_SOURCES})
-target_link_libraries(${PY_NAME} PUBLIC ${PROJECT_NAME} eigenpy::eigenpy)
+target_link_libraries(${PY_NAME} PUBLIC ${PROJECT_NAME}::${PROJECT_NAME}
+                                        eigenpy::eigenpy)
 
 set_target_properties(
   ${PY_NAME}

--- a/flake.nix
+++ b/flake.nix
@@ -11,22 +11,23 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = inputs.nixpkgs.lib.systems.flakeExposed;
       perSystem =
-        { pkgs, self', ... }:
+        {
+          lib,
+          pkgs,
+          self',
+          ...
+        }:
         {
           apps.default = {
             type = "app";
             program = pkgs.python3.withPackages (_: [ self'.packages.default ]);
           };
-          devShells.default = pkgs.mkShell {
-            inputsFrom = [ self'.packages.default ];
-            packages = [ (pkgs.python3.withPackages (p: [p.tomlkit])) ];
-          };
           packages = {
-            default = self'.packages.mim-solvers;
-            mim-solvers = pkgs.python3Packages.mim-solvers.overrideAttrs (old: {
-              src = pkgs.lib.fileset.toSource {
+            default = self'.packages.py-mim-solvers;
+            mim-solvers = pkgs.mim-solvers.overrideAttrs {
+              src = lib.fileset.toSource {
                 root = ./.;
-                fileset = pkgs.lib.fileset.unions [
+                fileset = lib.fileset.unions [
                   ./benchmarks
                   ./bindings
                   ./examples
@@ -38,7 +39,31 @@
                   ./package.xml
                 ];
               };
-            });
+            };
+            py-mim-solvers = pkgs.python3Packages.toPythonModule (
+              self'.packages.mim-solvers.overrideAttrs (super: {
+                pname = "py-${super.pname}";
+                postPatch = "";
+                cmakeFlags = super.cmakeFlags ++ [
+                  (lib.cmakeBool "BUILD_PYTHON_INTERFACE" true)
+                  (lib.cmakeBool "BUILD_STANDALONE_PYTHON_INTERFACE" true)
+                ];
+                nativeBuildInputs = super.nativeBuildInputs ++ [
+                  pkgs.python3Packages.python
+                ];
+                propagatedBuildInputs = [
+                  pkgs.python3Packages.crocoddyl
+                  pkgs.python3Packages.osqp
+                  pkgs.python3Packages.proxsuite
+                  pkgs.python3Packages.scipy
+                  self'.packages.mim-solvers
+                ]
+                ++ super.propagatedBuildInputs;
+                nativeCheckInputs = [
+                  pkgs.python3Packages.pythonImportsCheckHook
+                ];
+              })
+            );
           };
         };
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,13 +10,15 @@ set(${PROJECT_NAME}_FACTORY_TEST
     factory/solver.hpp
     factory/solver.cpp)
 
-add_library(${PROJECT_NAME}_unittest SHARED ${${PROJECT_NAME}_FACTORY_TEST})
-target_link_libraries(
-  ${PROJECT_NAME}_unittest PUBLIC ${PROJECT_NAME}
-                                  example-robot-data::example-robot-data)
+if(NOT BUILD_STANDALONE_PYTHON_INTERFACE)
+  add_library(${PROJECT_NAME}_unittest SHARED ${${PROJECT_NAME}_FACTORY_TEST})
+  target_link_libraries(
+    ${PROJECT_NAME}_unittest PUBLIC ${PROJECT_NAME}::${PROJECT_NAME}
+                                    example-robot-data::example-robot-data)
 
-add_unit_test(test_solvers test_solvers.cpp)
-target_link_libraries(test_solvers PUBLIC ${PROJECT_NAME}_unittest)
+  add_unit_test(test_solvers test_solvers.cpp)
+  target_link_libraries(test_solvers PUBLIC ${PROJECT_NAME}_unittest)
+endif()
 
 if(BUILD_PYTHON_INTERFACE)
   add_python_unit_test("py-test-clqr-convergence-all"


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Hi,

This update the CMake packaging of the project with the ability to build / install only the C++ library, and then rebuild the project with only the python interface, ref. https://github.com/jrl-umi3218/jrl-cmakemodules/pull/745

## How I Tested

I did split the nix packaging in 2 packages, and build that.