### PR TITLE
fixed osqp test

### DIFF
--- a/python/qp_solvers/qpsolvers.py
+++ b/python/qp_solvers/qpsolvers.py
@@ -276,12 +276,12 @@ class QPSolvers(SolverAbstract, CustomOSQP, StagewiseQPKKT):
                 nin_count += model.ng
 
         elif self.method == "OSQP":
-            Aeq = sparse.csr_matrix(A)
-            Aineq = sparse.csr_matrix(C)
+            Aeq = sparse.csc_matrix(A)
+            Aineq = sparse.csc_matrix(C)
             Aosqp = sparse.vstack([Aeq, Aineq])
             losqp = np.hstack([B, l])
             uosqp = np.hstack([B, u])
-            P = sparse.csr_matrix(P)
+            P = sparse.csc_matrix(P)
             if self.DEBUG:
                 print(
                     "nnz(P) = ",
@@ -306,14 +306,16 @@ class QPSolvers(SolverAbstract, CustomOSQP, StagewiseQPKKT):
                 Aosqp,
                 losqp,
                 uosqp,
-                warm_start=False,
+                warm_starting=False,
                 scaling=self.OSQP_scaling,
                 max_iter=self.max_qp_iters,
                 adaptive_rho=True,
+                adaptive_rho_interval=25,
                 verbose=self.verboseQP,
                 eps_rel=self.eps_rel,
                 eps_abs=self.eps_abs,
             )
+
             t1 = time.time()
             tmp = prob.solve()
             self.qp_time = time.time() - t1

--- a/tests/python/test_clqr_osqp.py
+++ b/tests/python/test_clqr_osqp.py
@@ -32,7 +32,7 @@ class TestCLQROSQP(unittest.TestCase):
         self.ddp2 = CSQP(self.problem, "OSQP")
         self.ddp1.with_callbacks = True
         self.ddp2.with_callbacks = True
-        max_qp_iters = 10000
+        max_qp_iters = 25
         self.ddp1.max_qp_iters = max_qp_iters
         self.ddp2.max_qp_iters = max_qp_iters
         eps_abs = 1e-8


### PR DESCRIPTION
Fixed OSQP unit-test. The test now passes with osqp 1.0.5

The test broke due to some changes in OSQP default parameters. I made sure all parameters match. I could not make the test run with more than 25 iterations. I think the novel check_dualgap [(#190)](https://github.com/osqp/osqp-python/pull/190) should be turned off. 

### Todo:
Check if the test runs with maxQPiters set to 1000 and check_dualgap to False.