### PR TITLE
tests: dont use relative path from build dir

### DIFF
--- a/tests/python/test_clqr_convergence_all.py
+++ b/tests/python/test_clqr_convergence_all.py
@@ -15,7 +15,7 @@ import pathlib
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402

--- a/tests/python/test_clqr_osqp.py
+++ b/tests/python/test_clqr_osqp.py
@@ -14,7 +14,7 @@ import pathlib
 import numpy as np
 import unittest
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402

--- a/tests/python/test_clqr_stagewise_admm.py
+++ b/tests/python/test_clqr_stagewise_admm.py
@@ -14,7 +14,7 @@ import pathlib
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402

--- a/tests/python/test_lqr_problem.py
+++ b/tests/python/test_lqr_problem.py
@@ -14,7 +14,7 @@ import pathlib
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from problems import create_lqr_problem  # noqa: E402

--- a/tests/python/test_qp_solo_all.py
+++ b/tests/python/test_qp_solo_all.py
@@ -21,7 +21,7 @@ import numpy as np
 import pinocchio
 import pinocchio as pin
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402

--- a/tests/python/test_qp_ur5_all.py
+++ b/tests/python/test_qp_ur5_all.py
@@ -20,7 +20,7 @@ import example_robot_data
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402

--- a/tests/python/test_sqp.py
+++ b/tests/python/test_sqp.py
@@ -14,7 +14,7 @@ import pathlib
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from problems import (  # noqa: E402

--- a/tests/python/test_sqp_taichi_convergence.py
+++ b/tests/python/test_sqp_taichi_convergence.py
@@ -15,7 +15,7 @@ import mim_solvers
 import numpy as np
 
 np.set_printoptions(precision=4, linewidth=180)
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from problems import create_taichi  # noqa: E402

--- a/tests/python/test_sqp_ur5_convergence.py
+++ b/tests/python/test_sqp_ur5_convergence.py
@@ -14,7 +14,7 @@ import pathlib
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from problems import create_unconstrained_ur5  # noqa: E402

--- a/tests/python/test_ur5_csqp.py
+++ b/tests/python/test_ur5_csqp.py
@@ -16,7 +16,7 @@ import example_robot_data
 import mim_solvers
 import numpy as np
 
-python_path = pathlib.Path(".").absolute().parent.parent / "python"
+python_path = pathlib.Path(__file__).absolute().parent.parent.parent / "python"
 os.sys.path.insert(1, str(python_path))
 
 from csqp import CSQP  # noqa: E402


### PR DESCRIPTION
## Description

Build dir (`"."`) could be anywhere. lets use source (`__file__`) instead.
Tests are broken on pip release because of that.

The right fix would be not to mess with `sys.path`, but I don't have time for that right now.

## Do not merge before

a better fix, ie. without `sys.path` manipulation, is implemented